### PR TITLE
Retool Platform.runStreams to return the termination status

### DIFF
--- a/core/src/main/scala/compstak/kafkastreams4s/Platform.scala
+++ b/core/src/main/scala/compstak/kafkastreams4s/Platform.scala
@@ -1,6 +1,6 @@
 package compstak.kafkastreams4s
 
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.{Async, ExitCase, ExitCode, Resource, Sync}
 import org.apache.kafka.streams.{KafkaStreams, Topology}
 import org.apache.kafka.streams.KafkaStreams.State
 import java.util.Properties
@@ -8,23 +8,34 @@ import java.time.Duration
 
 object Platform {
   def streamsResource[F[_]: Sync](top: Topology, props: Properties, timeout: Duration): Resource[F, KafkaStreams] =
-    Resource.make(Sync[F].delay(new KafkaStreams(top, props)))(s => Sync[F].delay(s.close(timeout)))
+    Resource.make(Sync[F].delay(new KafkaStreams(top, props)))(s =>
+      Sync[F].delay {
+        s.close(timeout)
+      }
+    )
 
-  def runStreams[F[_]: Async](streams: KafkaStreams): F[Unit] =
-    Async[F].async { (k: Either[Throwable, Unit] => Unit) =>
+  def runStreams[F[_]: Async](streams: KafkaStreams): F[Unit] = {
+    val run = Async[F].async { (k: Either[Throwable, Unit] => Unit) =>
       streams.setUncaughtExceptionHandler { (_: Thread, e: Throwable) =>
         k(Left(e))
       }
 
       streams.setStateListener { (state: State, _: State) =>
         state match {
-          case State.ERROR => k(Left(new RuntimeException("The KafkaStreams went into an ERROR state.")))
+          case State.ERROR =>
+            k(Left(new RuntimeException("The KafkaStreams went into an ERROR state.")))
           case _ => ()
         }
       }
 
       streams.start()
     }
+
+    Async[F].guaranteeCase(run) {
+      case ExitCase.Completed => Async[F].pure(())
+      case _ => Async[F].delay(System.exit(1))
+    }
+  }
 
   def run[F[_]: Async](topo: Topology, props: Properties, timeout: Duration): F[Unit] =
     streamsResource[F](topo, props, timeout).use(runStreams[F])

--- a/core/src/main/scala/compstak/kafkastreams4s/Platform.scala
+++ b/core/src/main/scala/compstak/kafkastreams4s/Platform.scala
@@ -1,42 +1,53 @@
 package compstak.kafkastreams4s
 
-import cats.effect.{Async, ExitCase, ExitCode, Resource, Sync}
+import cats._, cats.implicits._
+import cats.effect.{Async, Concurrent, ExitCase, ExitCode, Resource, Sync}
+import cats.effect.implicits._
+import cats.effect.concurrent.Deferred
 import org.apache.kafka.streams.{KafkaStreams, Topology}
 import org.apache.kafka.streams.KafkaStreams.State
 import java.util.Properties
 import java.time.Duration
+import org.apache.kafka.common.protocol.types.Field.Bool
+
+sealed trait ShutdownStatus
+final case object ShutdownComplete extends ShutdownStatus
+final case object ShutdownIncomplete extends ShutdownStatus
+
+object ShutdownStatus {
+  def apply(shutdown: Boolean): ShutdownStatus =
+    if (shutdown) {
+      ShutdownComplete
+    } else {
+      ShutdownIncomplete
+    }
+}
 
 object Platform {
-  def streamsResource[F[_]: Sync](top: Topology, props: Properties, timeout: Duration): Resource[F, KafkaStreams] =
-    Resource.make(Sync[F].delay(new KafkaStreams(top, props)))(s =>
-      Sync[F].delay {
-        s.close(timeout)
-      }
-    )
+  def run[F[_]: Concurrent](top: Topology, props: Properties, timeout: Duration): F[ShutdownStatus] =
+    for {
+      d <- Deferred[F, Boolean]
+      r <- Resource
+        .make(
+          Sync[F].delay(new KafkaStreams(top, props))
+        )(s => Sync[F].delay(s.close(timeout)).flatMap(b => d.complete(b)))
+        .use { streams =>
+          Async[F].async { (k: Either[Throwable, Unit] => Unit) =>
+            streams.setUncaughtExceptionHandler { (_: Thread, e: Throwable) =>
+              k(Left(e))
+            }
 
-  def runStreams[F[_]: Async](streams: KafkaStreams): F[Unit] = {
-    val run = Async[F].async { (k: Either[Throwable, Unit] => Unit) =>
-      streams.setUncaughtExceptionHandler { (_: Thread, e: Throwable) =>
-        k(Left(e))
-      }
+            streams.setStateListener { (state: State, _: State) =>
+              state match {
+                case State.ERROR =>
+                  k(Left(new RuntimeException("The KafkaStreams went into an ERROR state.")))
+                case _ => ()
+              }
+            }
 
-      streams.setStateListener { (state: State, _: State) =>
-        state match {
-          case State.ERROR =>
-            k(Left(new RuntimeException("The KafkaStreams went into an ERROR state.")))
-          case _ => ()
+            streams.start()
+          }
         }
-      }
-
-      streams.start()
-    }
-
-    Async[F].guaranteeCase(run) {
-      case ExitCase.Completed => Async[F].pure(())
-      case _ => Async[F].delay(System.exit(1))
-    }
-  }
-
-  def run[F[_]: Async](topo: Topology, props: Properties, timeout: Duration): F[Unit] =
-    streamsResource[F](topo, props, timeout).use(runStreams[F])
+        .redeemWith(_ => d.get, _ => d.get)
+    } yield ShutdownStatus(r)
 }

--- a/docs/src/Intro.md
+++ b/docs/src/Intro.md
@@ -61,19 +61,22 @@ Then we join the movies and purchases topics and lastly we use the `scanWith` op
 Now, all that's left is to direct the result into an output topic `example.output` and run the program
 
 ```scala mdoc:silent
-import cats.implicits._
-import cats.effect.IO
+import scala.concurrent.ExecutionContext
+import cats._, cats.implicits._
+import cats.effect._, cats.effect.implicits._
 import compstak.kafkastreams4s.Platform
 import org.apache.kafka.streams.Topology
 import java.util.Properties
 import java.time.Duration
+
+implicit val cs = IO.contextShift(ExecutionContext.global)
 
 val props = new Properties //in real code add the desired configuration to this object.
 
 val topology: IO[Topology] = result.to[IO]("example.output") >> IO(sb.build())
 
 val main: IO[Unit] = 
-  topology.flatMap(topo => Platform.run[IO](topo, props, Duration.ofSeconds(2)))
+  topology.flatMap(topo => Platform.run[IO](topo, props, Duration.ofSeconds(2))).void
 ```
 
 `compstak.kafkastreams4s.Platform` gives us a function `run` to run Kafka Streams programs and takes a topology, java properties and a timeout after which the stream threads will be shut off. 

--- a/tests/src/it/scala/compstak/kafkastreams4s/DebeziumEndToEndTests.scala
+++ b/tests/src/it/scala/compstak/kafkastreams4s/DebeziumEndToEndTests.scala
@@ -157,9 +157,7 @@ class DebeziumEndToEndTests extends munit.FunSuite {
       (a.payload.after.foldMap(_.foo), b.payload.after.foldMap(_.bar))
 
     def run: IO[Unit] =
-      topology.flatMap(top =>
-        Platform.streamsResource[IO](top, props, Duration.ofSeconds(2)).use(Platform.runStreams[IO])
-      )
+      topology.flatMap(top => Platform.run[IO](top, props, Duration.ofSeconds(2)).void)
   }
 
   object Consumer {


### PR DESCRIPTION
This PR:

1. Adds a `guaranteeCase` to `runStreams` so that in the event `close(Duration)` is called upon an error, we `System.exit(1)` the JVM so as not to possibly leave zombie non-daemon threads running, preventing the JVM from exiting at all, which e.g. makes the process look "healthy" to Nomad.